### PR TITLE
Implement FieldElement Struct for Field Arithmetic

### DIFF
--- a/src/field_element.rs
+++ b/src/field_element.rs
@@ -1,0 +1,114 @@
+// CONSTANTS
+// =============================================================================
+
+use std::{
+    fmt::{Display, Formatter, Result},
+    ops::{Add, AddAssign, Neg, Sub, SubAssign},
+};
+
+/// Prime number that defines the field the FieldElement is in. It is 2^64 - 2^32 + 1.
+const PRIME: u64 = 0xFFFFFFFF00000001;
+
+// STRUCTS
+// =============================================================================
+
+/// A field element is a number in the range 0..=MODULUS-1. It is represented
+/// as a u64, but it is not valid to create a FieldElement with a value >=
+/// PRIME.
+#[derive(Clone, Copy, Debug)]
+struct FieldElement {
+    value: u64,
+}
+
+/// IMPLEMENTATIONS
+/// =============================================================================
+
+impl FieldElement {
+    // CONSTANTS
+    const ZERO: FieldElement = FieldElement { value: 0 };
+    const ONE: FieldElement = FieldElement { value: 1 };
+
+    /// Create a new FieldElement. If the value is >= PRIME, then the value is
+    /// reduced modulo PRIME.
+    pub fn new(value: u64) -> FieldElement {
+        FieldElement {
+            value: value % PRIME,
+        }
+    }
+
+    /// Return the value of the FieldElement.
+    pub fn value(&self) -> u64 {
+        self.value
+    }
+}
+
+/// Implement the Display trait for FieldElement.
+impl Display for FieldElement {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f, "{}", self.value())
+    }
+}
+
+/// Implement the PartialEq trait for FieldElement.
+impl PartialEq for FieldElement {
+    #[inline]
+    fn eq(&self, other: &FieldElement) -> bool {
+        self.value() == other.value()
+    }
+}
+
+/// Implement Add, AddAssign, Sub, SubAssign, and Neg for FieldElement. These
+/// operations are performed modulo PRIME.
+impl Add for FieldElement {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, other: FieldElement) -> FieldElement {
+        let (result, carry) = self.value().overflowing_add(other.value());
+        Self {
+            value: result.wrapping_sub(PRIME * (carry as u64)),
+        }
+    }
+}
+
+impl AddAssign for FieldElement {
+    #[inline]
+    fn add_assign(&mut self, other: FieldElement) {
+        *self = *self + other;
+    }
+}
+
+impl Sub for FieldElement {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, other: FieldElement) -> FieldElement {
+        let (result, carry) = self.value().overflowing_sub(other.value());
+        Self {
+            value: result.wrapping_add(PRIME * (carry as u64)),
+        }
+    }
+}
+
+impl SubAssign for FieldElement {
+    #[inline]
+    fn sub_assign(&mut self, other: FieldElement) {
+        *self = *self - other;
+    }
+}
+
+impl Neg for FieldElement {
+    type Output = Self;
+
+    #[inline]
+    fn neg(self) -> FieldElement {
+        let value = self.value();
+        if value == 0 {
+            Self { value }
+        } else {
+            Self {
+                value: PRIME - value,
+            }
+        }
+    }
+}

--- a/src/field_element/mod.rs
+++ b/src/field_element/mod.rs
@@ -1,13 +1,19 @@
-// CONSTANTS
-// =============================================================================
-
 use std::{
     fmt::{Display, Formatter, Result},
     ops::{Add, AddAssign, Neg, Sub, SubAssign},
 };
 
+#[cfg(test)]
+mod tests;
+
+// CONSTANTS
+// =============================================================================
+
 /// Prime number that defines the field the FieldElement is in. It is 2^64 - 2^32 + 1.
 const PRIME: u64 = 0xFFFFFFFF00000001;
+
+const ZERO: FieldElement = FieldElement { value: 0 };
+const ONE: FieldElement = FieldElement { value: 1 };
 
 // STRUCTS
 // =============================================================================
@@ -24,10 +30,6 @@ struct FieldElement {
 /// =============================================================================
 
 impl FieldElement {
-    // CONSTANTS
-    const ZERO: FieldElement = FieldElement { value: 0 };
-    const ONE: FieldElement = FieldElement { value: 1 };
-
     /// Create a new FieldElement. If the value is >= PRIME, then the value is
     /// reduced modulo PRIME.
     pub fn new(value: u64) -> FieldElement {
@@ -63,11 +65,9 @@ impl Add for FieldElement {
     type Output = Self;
 
     #[inline]
-    fn add(self, other: FieldElement) -> FieldElement {
+    fn add(self, other: FieldElement) -> Self {
         let (result, carry) = self.value().overflowing_add(other.value());
-        Self {
-            value: result.wrapping_sub(PRIME * (carry as u64)),
-        }
+        Self::new(result.wrapping_sub(PRIME * (carry as u64)))
     }
 }
 
@@ -84,9 +84,7 @@ impl Sub for FieldElement {
     #[inline]
     fn sub(self, other: FieldElement) -> FieldElement {
         let (result, carry) = self.value().overflowing_sub(other.value());
-        Self {
-            value: result.wrapping_add(PRIME * (carry as u64)),
-        }
+        Self::new(result.wrapping_add(PRIME * (carry as u64)))
     }
 }
 

--- a/src/field_element/tests.rs
+++ b/src/field_element/tests.rs
@@ -1,0 +1,56 @@
+use super::{FieldElement, ONE, PRIME, ZERO};
+
+#[test]
+fn test_addition() {
+    // ---- Test addition with no carry ----------------------------------------
+
+    let a = FieldElement::new(15);
+    let b = FieldElement::new(35);
+
+    let result = a + b;
+    assert_eq!(result.value, 50);
+
+    // ------ Test addition with field overflow -----------------------------------------
+
+    let a = FieldElement::new(PRIME) - ONE;
+    let b = FieldElement::new(25);
+
+    let result = a + b;
+    assert_eq!(result.value, 24);
+
+    // ------ Test addition with u64 overflow -----------------------------------------
+
+    let a = FieldElement::new(PRIME - 1);
+    let b = FieldElement::new(PRIME - 2);
+
+    let result = a + b;
+    assert_eq!(result.value, PRIME - 3);
+}
+
+#[test]
+fn test_subtraction() {
+    // ---- Test subtraction with no carry ----------------------------------------
+
+    let a = FieldElement::new(15);
+    let b = FieldElement::new(35);
+
+    let result = b - a;
+    assert_eq!(result.value, 20);
+
+    // ------ Test subtraction with field underflow -----------------------------------------
+
+    let a = FieldElement::new(15);
+    let b = FieldElement::new(35);
+
+    let result = a - b;
+    assert_eq!(result.value, PRIME - 20);
+}
+
+#[test]
+fn test_negation() {
+    let a = FieldElement::new(15);
+
+    let result = -a;
+    assert_eq!(result.value, PRIME - 15);
+    assert_eq!(a + result, ZERO);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+mod field_element;


### PR DESCRIPTION
This PR partly addresses #1. We introduce the `FieldElement` struct that represents an element in the 64-bit field. This struct enables arithmetic operations (addition, subtraction, multiplication, division, and exponentiation) over the field, with proper handling of overflows in a 64-bit system.

It introduces the following operation in the field:

- addition
- subtraction
- negation