### PR TITLE
Implement multiplication for field arithmetic

### DIFF
--- a/src/field_element/mod.rs
+++ b/src/field_element/mod.rs
@@ -12,9 +12,6 @@ mod tests;
 /// Prime number that defines the field the FieldElement is in. It is 2^64 - 2^32 + 1.
 const PRIME: u64 = 0xFFFFFFFF00000001;
 
-/// 2^64 minus the field PRIME (coincidentally, 2^32 - 1).
-const E: u64 = 0xFFFFFFFF;
-
 const ZERO: FieldElement = FieldElement { value: 0 };
 const ONE: FieldElement = FieldElement { value: 1 };
 

--- a/src/field_element/tests.rs
+++ b/src/field_element/tests.rs
@@ -54,3 +54,34 @@ fn test_negation() {
     assert_eq!(result.value, PRIME - 15);
     assert_eq!(a + result, ZERO);
 }
+
+#[test]
+fn test_mul() {
+    // test multiplication by zero and one
+    let r: FieldElement = FieldElement::new(5);
+    assert_eq!(ZERO, r * ZERO);
+    assert_eq!(r, r * ONE);
+
+    // test basic multiplication
+    assert_eq!(FieldElement::from(15u8), FieldElement::from(5u8) * FieldElement::from(3u8));
+
+    // test multiplication which is guaranted to overflow
+    let m = PRIME;
+    let t = FieldElement::from(m - 1);
+    assert_eq!(ONE, t * t);
+    assert_eq!(FieldElement::from(m - 2), t * FieldElement::from(2u8));
+    assert_eq!(FieldElement::from(m - 4), t * FieldElement::from(4u8));
+
+    let t = (m + 1) / 2;
+    assert_eq!(ONE, FieldElement::from(t) * FieldElement::from(2u8));
+}
+
+fn test_square() {
+    let r: FieldElement = FieldElement::new(5);
+    assert_eq!(FieldElement::from(25u8), r.square());
+}
+
+fn test_cube() {
+    let r: FieldElement = FieldElement::new(5);
+    assert_eq!(FieldElement::from(125u8), r.cube());
+}


### PR DESCRIPTION
The `FieldElement` struct supports multiplication after this change. The multiplication is done over the Goldilocks field by first undertaking integer multiplication and then reducing the result to the field.

Partially addresses #1