### PR TITLE
Rescue prime parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 authors = ["Kaneki Ken <starkkaneki@protonmail.com>"]
 license = "MIT"
+
+[dependencies]
+sha3 = "0.10.7"

--- a/src/field_element/mod.rs
+++ b/src/field_element/mod.rs
@@ -10,10 +10,10 @@ mod tests;
 // =============================================================================
 
 /// Prime number that defines the field the FieldElement is in. It is 2^64 - 2^32 + 1.
-const PRIME: u64 = 0xFFFFFFFF00000001;
+pub const PRIME: u64 = 0xFFFFFFFF00000001;
 
-const ZERO: FieldElement = FieldElement { value: 0 };
-const ONE: FieldElement = FieldElement { value: 1 };
+pub const ZERO: FieldElement = FieldElement { value: 0 };
+pub const ONE: FieldElement = FieldElement { value: 1 };
 
 // STRUCTS
 // =============================================================================
@@ -22,7 +22,7 @@ const ONE: FieldElement = FieldElement { value: 1 };
 /// as a u64, but it is not valid to create a FieldElement with a value >=
 /// PRIME.
 #[derive(Clone, Copy, Debug)]
-struct FieldElement {
+pub struct FieldElement {
     value: u64,
 }
 
@@ -306,7 +306,7 @@ impl From<u8> for FieldElement {
 /// This function reduces a 128-bit number modulo PRIME, based on the instructions at the link below.
 /// https://cp4space.hatsya.com/2021/09/01/an-efficient-prime-for-number-theoretic-transforms/
 #[inline]
-fn reduce(x: u128) -> u64 {
+pub fn reduce(x: u128) -> u64 {
     // Split the 128-bit number into 3 parts, such that the number can be written as follows.
     // x = low + 2^64 * middle + 2^96 * high
     let low: u64 = x as u64; // low 64 bits

--- a/src/generate_params.rs
+++ b/src/generate_params.rs
@@ -1,0 +1,64 @@
+use super::field_element::{reduce, FieldElement, PRIME, ZERO};
+use sha3::{
+    digest::{ExtendableOutput, Update},
+    Shake256,
+};
+
+/// This function generates the round constants for the Rescue hash function.
+#[allow(dead_code)]
+pub fn compute_round_constants<const RATE: usize, const WIDTH: usize, const N: usize>(
+    security_level: usize,
+) -> [[[FieldElement; WIDTH]; N]; 2] {
+    // compute the number of bytes needed to represent a single FieldElement
+    // bytes_per_field = $ceil(|p| / 8) + 1#
+    // where |p| is the number of bits in the PRIME
+    let bytes_per_field = 9;
+    let num_bytes = bytes_per_field * WIDTH * N * 2;
+
+    // number of fields elements not impacted during absorb operation.
+    let capacity = WIDTH - RATE;
+
+    // seed_string = "Rescue - XLIX (p, w, c, security_level)" mentioned in the paper.
+    let seed_string = format!("Rescue - XLIX ({},{},{},{}", PRIME, WIDTH, capacity, security_level);
+
+    let seed_bytes = seed_string.as_bytes();
+    let byte_string = shake256(seed_bytes, num_bytes);
+
+    let mut round_constants = [[[ZERO; WIDTH]; N]; 2];
+
+    // process byte_string into chunks of bytes_per_field.
+    for i in 0..2 * WIDTH * N {
+        let bytes_chunk = byte_string[i * bytes_per_field..(i + 1) * bytes_per_field].to_vec();
+
+        let constant = bytes_chunk
+            .iter()
+            .enumerate()
+            .map(|(i, val)| {
+                // calculate the integer value of the chunk using least significant byte first encoding.
+                let pow = 256u128.pow(i as u32);
+                let zz = *val as u128;
+                pow * zz
+            })
+            .sum::<u128>();
+
+        // reduce the constant to a `u64` value.
+        let reduced_constant = reduce(constant);
+
+        round_constants[i / (WIDTH * N)][i / WIDTH % N][i % WIDTH] =
+            FieldElement::new(reduced_constant);
+    }
+
+    round_constants
+}
+
+// HELPER METHODS
+/// ================================================================================================
+
+/// This function returns a `Box<[u8]>` of `num_bytes` length. The bytes are generated using the
+/// SHAKE256 hash function.
+#[allow(dead_code)]
+fn shake256(input: &[u8], num_bytes: usize) -> Box<[u8]> {
+    let mut hasher = Shake256::default();
+    hasher.update(input);
+    hasher.finalize_boxed(num_bytes)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 mod field_element;
+mod generate_params;


### PR DESCRIPTION
This PR partly addresses #8. It introduces a function which generates the `round_constants` which are being used in the rescue-prime rounds.